### PR TITLE
Issue 33

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # quanteda.textstats 0.94
 
-Move the S4 definitions for simil, dist, and proxy textstat classes from **quanteda** to **quanteda.textstats**.
+* Move the S4 definitions for simil, dist, and proxy textstat classes from **quanteda** to **quanteda.textstats**.
+* Changes the operation of `groups` in `textstat_frequency()` to operate as in **quanteda** v3.
 
 # quanteda.textstats 0.93
 

--- a/R/textstat_frequency.R
+++ b/R/textstat_frequency.R
@@ -38,10 +38,17 @@
 #'
 #' dfmat2 <- corpus_subset(data_corpus_inaugural, President == "Obama") %>%
 #'    tokens(remove_punct = TRUE) %>%
-#'    tokens_remove(stopwords("english")) %>%
+#'    tokens_remove(stopwords("en")) %>%
 #'    dfm()
 #' tstat1 <- textstat_frequency(dfmat2)
 #' head(tstat1, 10)
+#'
+#' dfmat3 <- head(data_corpus_inaugural) %>%
+#'    tokens(remove_punct = TRUE) %>%
+#'    tokens_remove(stopwords("en")) %>%
+#'    dfm()
+#' textstat_frequency(dfmat3, n = 2, groups = President)
+#'
 #'
 #' \dontrun{
 #' # plot 20 most frequent words
@@ -54,12 +61,14 @@
 #' # plot relative frequencies by group
 #' dfmat3 <- data_corpus_inaugural %>%
 #'     corpus_subset(Year > 2000) %>%
-#'     dfm(remove = stopwords("english"), remove_punct = TRUE) %>%
-#'     dfm_group(groups = "President") %>%
+#'     tokens(remove_punct = TRUE) %>%
+#'     tokens_remove(stopwords("en")) %>%
+#'     dfm() %>%
+#'     dfm_group(groups = President) %>%
 #'     dfm_weight(scheme = "prop")
 #'
 #' # calculate relative frequency by president
-#' tstat2 <- textstat_frequency(dfmat3, n = 10, groups = "President")
+#' tstat2 <- textstat_frequency(dfmat3, n = 10, groups = President)
 #'
 #' # plot frequencies
 #' ggplot(data = tstat2, aes(x = factor(nrow(tstat2):1), y = frequency)) +
@@ -99,8 +108,15 @@ textstat_frequency.dfm <- function(x, n = NULL, groups = NULL,
     if (!sum(x))
         stop(message_error("dfm_empty"))
 
-    if (is.null(groups))
+    if (missing(groups)) {
         groups <- rep("all", ndoc(x))
+    } else {
+        field <- deparse(substitute(groups))
+        groups <- eval(substitute(groups), get_docvars(x, user = TRUE, system = TRUE), parent.frame())
+        if (!field %in% names(get_docvars(x)) || !is.factor(groups))
+            field <- NULL
+        groups <- as.factor(groups)
+    }
 
     tf <- x
     tf <- dfm_group(tf, groups, ...)

--- a/R/textstat_readability.R
+++ b/R/textstat_readability.R
@@ -528,7 +528,7 @@ textstat_readability.corpus <- function(x,
         measure <- unique(measure)
     }
 
-    x <- texts(x)
+    x <- as.character(x)
     if (!is.null(min_sentence_length) || !is.null(max_sentence_length)) {
         temp <- char_trim(x, "sentences",
                           min_ntoken = min_sentence_length,

--- a/R/utils.R
+++ b/R/utils.R
@@ -2,6 +2,8 @@ friendly_class_undefined_message <- quanteda:::friendly_class_undefined_message
 message_error <- quanteda:::message_error
 removals_regex <- quanteda:::removals_regex
 pad_dfm <- quanteda:::pad_dfm
+get_docvars <- quanteda:::get_docvars
+get_docvars.dfm <- quanteda:::get_docvars.dfm
 
 #' Check arguments passed to other functions via ...
 #' @param ... dots to check

--- a/man/textstat_frequency.Rd
+++ b/man/textstat_frequency.Rd
@@ -66,10 +66,17 @@ textstat_frequency(dfmat1, groups = c("one", "two", "one"), ties_method = "avera
 
 dfmat2 <- corpus_subset(data_corpus_inaugural, President == "Obama") \%>\%
    tokens(remove_punct = TRUE) \%>\%
-   tokens_remove(stopwords("english")) \%>\%
+   tokens_remove(stopwords("en")) \%>\%
    dfm()
 tstat1 <- textstat_frequency(dfmat2)
 head(tstat1, 10)
+
+dfmat3 <- head(data_corpus_inaugural) \%>\%
+   tokens(remove_punct = TRUE) \%>\%
+   tokens_remove(stopwords("en")) \%>\%
+   dfm()
+textstat_frequency(dfmat3, n = 2, groups = President)
+
 
 \dontrun{
 # plot 20 most frequent words
@@ -82,12 +89,14 @@ ggplot(tstat1[1:20, ], aes(x = reorder(feature, frequency), y = frequency)) +
 # plot relative frequencies by group
 dfmat3 <- data_corpus_inaugural \%>\%
     corpus_subset(Year > 2000) \%>\%
-    dfm(remove = stopwords("english"), remove_punct = TRUE) \%>\%
-    dfm_group(groups = "President") \%>\%
+    tokens(remove_punct = TRUE) \%>\%
+    tokens_remove(stopwords("en")) \%>\%
+    dfm() \%>\%
+    dfm_group(groups = President) \%>\%
     dfm_weight(scheme = "prop")
 
 # calculate relative frequency by president
-tstat2 <- textstat_frequency(dfmat3, n = 10, groups = "President")
+tstat2 <- textstat_frequency(dfmat3, n = 10, groups = President)
 
 # plot frequencies
 ggplot(data = tstat2, aes(x = factor(nrow(tstat2):1), y = frequency)) +

--- a/tests/testthat/test-textstat_collocations.R
+++ b/tests/testthat/test-textstat_collocations.R
@@ -6,6 +6,8 @@
 
 # ************************************************************
 
+library("quanteda")
+
 MWEcounts <- function(candidate, text, stopword = "xxxx") {
     # Function for creating the 2^K table of yes/no occurrences
     # in text (character vector)
@@ -197,7 +199,7 @@ test_that("test the correctness of significant", {
 
 test_that("collocation is counted correctly in racing conditions, issue #381", {
     n <- 100 # NOTE: n must be large number to create racing conditionc
-    txt <- unname(rep(quanteda::texts(quanteda::data_corpus_inaugural)[1], n))
+    txt <- unname(rep(as.character(quanteda::data_corpus_inaugural)[1], n))
     toks <- quanteda::tokens(txt)
     out1 <- textstat_collocations(toks[1], size = 2, min_count = 1)
     out100 <- textstat_collocations(toks, size = 2, min_count = 1)

--- a/tests/testthat/test-textstat_frequency.R
+++ b/tests/testthat/test-textstat_frequency.R
@@ -29,10 +29,14 @@ test_that("test textstat_frequency without groups", {
         textstat_frequency(quanteda::dfm(quanteda::tokens(corp1)), groups = grp1, ties_method = "max"),
         textstat_frequency(quanteda::dfm(quanteda::tokens(corp1)), groups = corp1$grp2, ties_method = "max")
     )
+    expect_identical(
+        textstat_frequency(quanteda::dfm(quanteda::tokens(corp1)), groups = grp1, ties_method = "max"),
+        textstat_frequency(quanteda::dfm(quanteda::tokens(corp1)), groups = grp2, ties_method = "max")
+    )
 
     set.seed(10)
     expect_equivalent(
-        textstat_frequency(quanteda::dfm(quanteda::tokens(corp1)), groups = grp1, ties_method = "random"),
+        textstat_frequency(quanteda::dfm(quanteda::tokens(corp1)), groups = grp2, ties_method = "random"),
         data.frame(feature = c("a", "b", "c", "d", "d", "a"),
                    frequency = c(5,2,1,1,3,1),
                    rank = c(1:4, 1:2),
@@ -42,7 +46,7 @@ test_that("test textstat_frequency without groups", {
     )
 
     expect_equivalent(
-      textstat_frequency(quanteda::dfm(quanteda::tokens(corp1)), groups = grp1, n = 2, ties_method = "random"),
+      textstat_frequency(quanteda::dfm(quanteda::tokens(corp1)), groups = grp2, n = 2, ties_method = "random"),
       data.frame(feature = c("a", "b", "d", "a"),
                  frequency = c(5, 2, 3, 1),
                  rank = c(1:2, 1:2),

--- a/tests/testthat/test-textstat_lexdiv.R
+++ b/tests/testthat/test-textstat_lexdiv.R
@@ -87,8 +87,9 @@ test_that("Yule's K and Herndon's Vm correction are (approximately) correct", {
     df <- read.csv("../data/stjohn_latin.csv", stringsAsFactors = FALSE)
     data_corpus_stjohn <- df %>%
         corpus(text_field = "latin") %>%
-        texts(groups = df$chapter) %>%  # combine verses into a single document
-        corpus(docvars = data.frame(chapter = 1:4))
+        corpus_group(groups = df$chapter) # %>%
+        # as.character() %>%  # combine verses into a single document
+        # corpus(docvars = data.frame(chapter = 1:4))
     docnames(data_corpus_stjohn) <- paste0("chap", 1:4)
 
     data_dfm_stjohn <- data_corpus_stjohn %>%

--- a/tests/testthat/test-textstat_readability.R
+++ b/tests/testthat/test-textstat_readability.R
@@ -1,5 +1,4 @@
-data_char_sampletext <- quanteda::data_char_sampletext
-`%>%` <- quanteda::`%>%`
+library("quanteda")
 
 test_that("readability works: basic", {
     txt <- "This was adjusted by a prolongation of the period of reimbursement in nature of a new loan


### PR DESCRIPTION
- Solves #33 by using **quanteda** v3 `groups` usage in `textstat_frequency()`
- Fixes some pre-v3 usage in examples and tests to avoid warnings.

Note to @koheiw: We should probably add `get_docvars()` to the set of utility/developer functions that we need to export from **quanteda**.