### PR TITLE
Disable emoji count when ICU is old

### DIFF
--- a/R/textstat_summary.R
+++ b/R/textstat_summary.R
@@ -65,21 +65,30 @@ textstat_summary.dfm <- function(x, ...) {
 }
 
 summarize <- function(x, ...) {
-
+    
+    # for old ICU
+    skip_emoji <- as.numeric(stringi::stri_info()[["Unicode.version"]]) < 11
+    
     patterns <- removals_regex(punct = TRUE, symbols = TRUE,
                                numbers = TRUE, url = TRUE)
     patterns[["tag"]] <-
         list("username" = paste0("^", quanteda::quanteda_options("pattern_username"), "$"),
              "hashtag" = paste0("^", quanteda::quanteda_options("pattern_hashtag"), "$"))
-    patterns[["emoji"]] <- "^\\p{Emoji_Presentation}+$"
+    
+    if (!skip_emoji) 
+        patterns[["emoji"]] <- "^\\p{Emoji_Presentation}+$"
+    
     dict <- quanteda::dictionary(patterns)
-
     y <- dfm(if (is.corpus(x)) tokens(x) else x, ...)
     temp <- quanteda::convert(
         quanteda::dfm_lookup(y, dictionary = dict, valuetype = "regex", levels = 1),
         "data.frame",
         docid_field = "document"
     )
+    
+    if (skip_emoji) 
+        temp$emoji <- NA
+    
     result <- data.frame(
         "document" = quanteda::docnames(y),
         "chars" = NA,

--- a/R/textstat_summary.R
+++ b/R/textstat_summary.R
@@ -67,7 +67,7 @@ textstat_summary.dfm <- function(x, ...) {
 summarize <- function(x, ...) {
     
     # for old ICU
-    skip_emoji <- as.numeric(stringi::stri_info()[["Unicode.version"]]) < 11
+    skip_emoji <- as.numeric(stringi::stri_info()[["Unicode.version"]]) < 9
     
     patterns <- removals_regex(punct = TRUE, symbols = TRUE,
                                numbers = TRUE, url = TRUE)


### PR DESCRIPTION
For #24 and #35. I could not figure out when `Emoji_Presentation` became available, but ICU 11.0 seems to be the turning point. Please check the emoji column become all NA on your old machine.

> Starting with Version 11.0 of this specification, the repertoire of emoji characters is synchronized with the Unicode Standard, and has the same version numbering system. For details, see Section 1.5.2, Versioning.

http://www.unicode.org/reports/tr51/#Emoji_Properties