### PR TITLE
Prepare for proxyC v0.2.1

### DIFF
--- a/R/textstat_simil.R
+++ b/R/textstat_simil.R
@@ -635,9 +635,13 @@ textstat_proxy <- function(x, y = NULL,
     if (method %in% c("cosine", "correlation", "jaccard", "ejaccard", "dice", "edice",
                       "hamman", "simple matching", "faith")) {
         if (identical(x, y)) {
-            result <- proxyC::simil(x, NULL, 2, method, min_simil = min_proxy, rank = rank)
+            suppressWarnings({
+                result <- proxyC::simil(x, NULL, 2, method, min_simil = min_proxy, rank = rank)
+            })
         } else {
-            result <- proxyC::simil(x, y, 2, method, min_simil = min_proxy, rank = rank)
+            suppressWarnings({
+                result <- proxyC::simil(x, y, 2, method, min_simil = min_proxy, rank = rank)
+            })
         }
     } else {
         if (identical(x, y)) {

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -6,6 +6,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // qatd_cpp_collocations
 DataFrame qatd_cpp_collocations(const List& texts_, const CharacterVector& types_, const IntegerVector& words_ignore_, const unsigned int count_min, const IntegerVector sizes_, const String& method, const double smoothing);
 RcppExport SEXP _quanteda_textstats_qatd_cpp_collocations(SEXP texts_SEXP, SEXP types_SEXP, SEXP words_ignore_SEXP, SEXP count_minSEXP, SEXP sizes_SEXP, SEXP methodSEXP, SEXP smoothingSEXP) {


### PR DESCRIPTION
Suppress warnings by proxyC v0.2.1. I said in #41 that `use_nan` will help to simplify the code, but it only affects `method = correlation`. I could not find a reason to return `NaN` when vectors are all zero in other similarity/distance measures.