### PR TITLE
Update proxy c

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,12 +1,10 @@
-# For help debugging build failures open an issue on the RStudio community with the 'github-actions' tag.
-# https://community.rstudio.com/new-topic?category=Package%20development&tags=github-actions
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches:
-      - master
+    branches: [main, master]
   pull_request:
-    branches:
-      - master
+    branches: [main, master]
 
 name: R-CMD-check
 
@@ -20,63 +18,37 @@ jobs:
       fail-fast: false
       matrix:
         config:
+          - {os: macOS-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
-          - {os: macOS-latest, r: 'release'}
-          - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: ubuntu-20.04, r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
 
     env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: ${{ matrix.config.rspm }}
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
 
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-pandoc@v1
+
+      - uses: r-lib/actions/setup-r@v1
         with:
           r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
 
-      - uses: r-lib/actions/setup-pandoc@master
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Cache R packages
-        if: runner.os != 'Windows'
-        uses: actions/cache@v1
+      - uses: r-lib/actions/setup-r-dependencies@v1
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+          extra-packages: rcmdcheck
 
-      - name: Install remotes
-        run: >
-          Rscript
-          -e "if (system.file(package = 'remotes') == '') install.packages('remotes')"
+      - uses: r-lib/actions/check-r-package@v1
 
-      - name: Install system dependencies
-        if: runner.os == 'Linux'
-        run: |
-          while read -r cmd
-          do
-            eval sudo $cmd
-          done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "20.04"), sep = "\n")')
-
-      - name: Install dependencies
-        run: |
-          remotes::install_deps(dependencies = TRUE)
-          remotes::install_cran("rcmdcheck")
-        shell: Rscript {0}
-
-      - name: Check
-        env:
-          _R_CHECK_CRAN_INCOMING_REMOTE_: false
-        run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
-        shell: Rscript {0}
+      - name: Show testthat output
+        if: always()
+        run: find check -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash
 
       - name: Upload check results
         if: failure()

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: quanteda.textstats
-Version: 0.94.1
+Version: 0.94.1.9000
 Title: Textual Statistics for the Quantitative Analysis of Textual Data
 Description: Textual statistics functions formerly in the 'quanteda' package.
     Textual statistics for characterizing and comparing textual data. Includes 
@@ -42,6 +42,6 @@ Encoding: UTF-8
 BugReports: https://github.com/quanteda/quanteda.textstats/issues
 LazyData: TRUE
 Language: en-GB
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 SystemRequirements: C++11
 Roxygen: list(markdown = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
+# quanteda.textstats 0.94.2
+
+* Updated `textstat_simil()` for new **proxyC** version v0.2.2, which affects how similarities are returned for `NA` values.  See #45.
+
 # quanteda.textstats 0.94.1
 
-* Updated `textstat_simil()` for new **proxyC** version v2.0.
+* Updated `textstat_simil()` for new **proxyC** version v-0.2.0.
 * Now returns emoji counts as `NA`, without failure, for ICU versions older than 9 (#35 and #24).
 
 # quanteda.textstats 0.94

--- a/R/textstat_simil.R
+++ b/R/textstat_simil.R
@@ -636,11 +636,11 @@ textstat_proxy <- function(x, y = NULL,
                       "hamman", "simple matching", "faith")) {
         if (identical(x, y)) {
             suppressWarnings({
-                result <- proxyC::simil(x, NULL, 2, method, min_simil = min_proxy, rank = rank)
+                result <- proxyC::simil(x, NULL, 2, method, min_simil = min_proxy, rank = rank, use_nan = use_na)
             })
         } else {
             suppressWarnings({
-                result <- proxyC::simil(x, y, 2, method, min_simil = min_proxy, rank = rank)
+                result <- proxyC::simil(x, y, 2, method, min_simil = min_proxy, rank = rank, use_nan = use_na)
             })
         }
     } else {
@@ -651,39 +651,6 @@ textstat_proxy <- function(x, y = NULL,
         }
     }
     dimnames(result) <- list(colnames(x), colnames(y))
-    if (use_na) {
-        if (method == "correlation") {
-            na1 <- proxyC::colSds(x) == 0
-            na2 <- proxyC::colSds(y) == 0
-        } else {
-            na1 <- proxyC::colZeros(x) == nrow(x)
-            na2 <- proxyC::colZeros(y) == nrow(y)
-        }
-        if (any(na1) || any(na2))
-            result <- result + make_na_matrix(dim(result), which(na1), which(na2))
-    }
     return(result)
 }
 
-make_na_matrix <- function(dims, row = NULL, col = NULL) {
-    i <- j <- integer()
-    if (is.integer(row)) {
-        i <- c(i, rep(row, dims[2]))
-        j <- c(j, rep(seq_len(dims[2]), each = length(row)))
-    }
-    if (is.integer(col)) {
-        i <- c(i, rep(seq_len(dims[1]), each = length(col)))
-        j <- c(j, rep(col, dims[1]))
-    }
-    if (utils::packageVersion("Matrix") < 1.3) {
-        Matrix::sparseMatrix(
-            i = i, j = j, x = as.double(NA),
-            dims = dims,
-            giveCsparse = FALSE)
-    } else {
-        Matrix::sparseMatrix(
-            i = i, j = j, x = as.double(NA),
-            dims = dims,
-            repr = "T")
-    }
-}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![CRAN
 Version](https://www.r-pkg.org/badges/version/quanteda.textstats)](https://CRAN.R-project.org/package=quanteda.textstats)
-[![](https://img.shields.io/badge/devel%20version-0.94-royalblue.svg)](https://github.com/quanteda/quanteda.textstats)
+[![](https://img.shields.io/badge/devel%20version-0.94.1.9000-royalblue.svg)](https://github.com/quanteda/quanteda.textstats)
 [![Downloads](https://cranlogs.r-pkg.org/badges/quanteda.textstats)](https://CRAN.R-project.org/package=quanteda.textstats)
 [![Total
 Downloads](https://cranlogs.r-pkg.org/badges/grand-total/quanteda.textstats?color=orange)](https://CRAN.R-project.org/package=quanteda.textstats)

--- a/man/quanteda.textstats-package.Rd
+++ b/man/quanteda.textstats-package.Rd
@@ -6,12 +6,7 @@
 \alias{quanteda.textstats-package}
 \title{quanteda.textstats: Textual Statistics for the Quantitative Analysis of Textual Data}
 \description{
-Textual statistics functions formerly in the 'quanteda' package.
-    Textual statistics for characterizing and comparing textual data. Includes 
-    functions for measuring term and document frequency, the co-occurrence of 
-    words, similarity and distance between features and documents, feature entropy, 
-    keyword occurrence, readability, and lexical diversity.  These functions 
-    extend the 'quanteda' package and are specially designed for sparse textual data.
+Textual statistics functions formerly in the 'quanteda' package. Textual statistics for characterizing and comparing textual data. Includes functions for measuring term and document frequency, the co-occurrence of words, similarity and distance between features and documents, feature entropy, keyword occurrence, readability, and lexical diversity. These functions extend the 'quanteda' package and are specially designed for sparse textual data.
 }
 \seealso{
 Useful links:

--- a/tests/testthat/test-textstat_dist.R
+++ b/tests/testthat/test-textstat_dist.R
@@ -1,6 +1,9 @@
-mt <- quanteda::dfm(quanteda::tokens(quanteda::corpus_subset(quanteda::data_corpus_inaugural, Year > 1980)))
-mt <- quanteda::dfm_trim(mt, min_termfreq = 10)
-`%>%` <- quanteda::`%>%`
+library("quanteda")
+
+mt <- corpus_subset(data_corpus_inaugural, Year > 1980 & Year < 2021) %>% 
+  tokens() %>% 
+  dfm()
+mt <- dfm_trim(mt, min_termfreq = 10)
 
 test_that("dist object has all the attributes", {
     d1 <- textstat_dist(mt) %>% as.matrix %>% as.dist()
@@ -22,7 +25,7 @@ test_that("selection takes integer or logical vector", {
     suppressWarnings({
     expect_equivalent(textstat_dist(mt, selection = c(2, 5), margin = "features"),
                       textstat_dist(mt, selection = c("mr", "president"), margin = "features"))
-    l3 <- quanteda::featnames(mt) %in% c("mr", "president")
+    l3 <- featnames(mt) %in% c("mr", "president")
     expect_equivalent(textstat_dist(mt, selection = l3, margin = "features"),
                       textstat_dist(mt, selection = c("mr", "president"), margin = "features"))
     })
@@ -32,7 +35,7 @@ test_that("selection takes integer or logical vector", {
 
     expect_equivalent(textstat_dist(mt, y = mt[c(2, 4), ], margin = "documents"),
                       textstat_dist(mt, y = mt[c("1985-Reagan", "1993-Clinton"), ], margin = "documents"))
-    l4 <- quanteda::docnames(mt) %in% c("1985-Reagan", "1993-Clinton")
+    l4 <- docnames(mt) %in% c("1985-Reagan", "1993-Clinton")
     expect_equivalent(textstat_dist(mt, y = mt[l4, ], margin = "documents"),
                       textstat_dist(mt, y = mt[c("1985-Reagan", "1993-Clinton"), ], margin = "documents"))
 
@@ -40,67 +43,63 @@ test_that("selection takes integer or logical vector", {
     expect_error(textstat_dist(mt, y = 100, margin = "documents"))
 })
 
-test_that("textstat_dist() returns NA for empty dfm", {
-    mt <- quanteda::dfm_trim(quanteda::data_dfm_lbgexample, 1000)
-    expect_equivalent(
-        textstat_dist(mt, method = "euclidean") %>% as.matrix() %>% as.dist(),
-        stats::dist(as.matrix(mt), method = "euclidean")
-    )
+# test_that("textstat_dist() returns NA for empty dfm", {
+    # mt <- dfm_trim(data_dfm_lbgexample, 1000)
+    # stats::dist is wrong
     # expect_equivalent(
-    #     textstat_dist(mt, method = "kullback") %>% as.matrix() %>% as.dist(),
-    #     proxy::dist(as.matrix(mt), method = "kullback")
+    #     textstat_dist(mt, method = "euclidean") %>% as.matrix() %>% as.dist(),
+    #     stats::dist(as.matrix(mt), method = "euclidean")
     # )
-    expect_equivalent(
-        textstat_dist(mt, method = "manhattan") %>% as.matrix() %>% as.dist(),
-        stats::dist(as.matrix(mt), method = "manhattan")
-    )
-    # FAILS
+    # stats::dist is wrong
+    # expect_equivalent(
+    #     textstat_dist(mt, method = "manhattan") %>% as.matrix() %>% as.dist(),
+    #     stats::dist(as.matrix(mt), method = "manhattan")
+    # )
+    # stats::dist is wrong
     # expect_equivalent(
     #     textstat_dist(mt, method = "maximum") %>% as.matrix() %>% as.dist(),
     #     stats::dist(as.matrix(mt), method = "maximum")
     # )
-    expect_equivalent(
-        textstat_dist(mt, method = "canberra") %>% as.matrix() %>% as.dist(),
-        stats::dist(as.matrix(mt), method = "canberra")
-    )
-    expect_equivalent(
-        textstat_dist(mt, method = "minkowski") %>% as.matrix() %>% as.dist(),
-        stats::dist(as.matrix(mt), method = "minkowski", p = 2)
-    )
-})
+    # stats::dist is wrong
+    # expect_equivalent(
+    #     textstat_dist(mt, method = "canberra") %>% as.matrix() %>% as.dist(),
+    #     stats::dist(as.matrix(mt), method = "canberra")
+    # )
+    # stats::dist is wrong
+    # expect_equivalent(
+    #     textstat_dist(mt, method = "minkowski") %>% as.matrix() %>% as.dist(),
+    #     stats::dist(as.matrix(mt), method = "minkowski", p = 2)
+    # )
+# })
 
 test_that("textstat_dist() returns NA for zero-variance documents", {
-    skip("skip until textstat_dist() works correctly for zero-variance documents")
-    mt <- quanteda::data_dfm_lbgexample[1:5, 1:20]
+    
+    mt <- data_dfm_lbgexample[1:5, 1:20]
     mt[1:2, ] <- 0
     mt[3:4, ] <- 1
-    mt <- quanteda::as.dfm(mt)
+    mt <- as.dfm(mt)
 
-    # fails
     expect_equivalent(
         textstat_dist(mt, method = "euclidean") %>% as.matrix() %>% as.dist(),
         stats::dist(as.matrix(mt), method = "euclidean")
     )
-    # expect_equivalent(
-    #     textstat_dist(mt, method = "kullback") %>% as.matrix() %>% as.dist(),
-    #     proxy::dist(as.matrix(mt), method = "kullback")
-    # )
-    # fails
+    
     expect_equivalent(
         textstat_dist(mt, method = "manhattan") %>% as.matrix() %>% as.dist(),
         stats::dist(as.matrix(mt), method = "manhattan")
     )
-    # fails
+    
     expect_equivalent(
         textstat_dist(mt, method = "maximum") %>% as.matrix() %>% as.dist(),
         stats::dist(as.matrix(mt), method = "maximum")
     )
-    # fails
-    expect_equivalent(
-        textstat_dist(mt, method = "canberra") %>% as.matrix() %>% as.dist(),
-        stats::dist(as.matrix(mt), method = "canberra")
-    )
-    # fails
+    
+    # stats::dist is wrong
+    # expect_equivalent(
+    #     textstat_dist(mt, method = "canberra") %>% as.matrix() %>% as.dist(),
+    #     stats::dist(as.matrix(mt), method = "canberra")
+    # )
+    
     expect_equivalent(
         textstat_dist(mt, method = "minkowski") %>% as.matrix() %>% as.dist(),
         stats::dist(as.matrix(mt), method = "minkowski", p = 2)
@@ -108,7 +107,7 @@ test_that("textstat_dist() returns NA for zero-variance documents", {
 })
 
 test_that("selection is always on columns (#1549)", {
-    mt <- quanteda::dfm(quanteda::tokens(quanteda::corpus_subset(quanteda::data_corpus_inaugural, Year > 1980)))
+    mt <- dfm(tokens(corpus_subset(data_corpus_inaugural, Year > 1980)))
     suppressWarnings({
         expect_equal(
         colnames(textstat_dist(mt, margin = "documents",
@@ -144,18 +143,18 @@ test_that("textstat_dist coercion methods work with options", {
     tstat <- textstat_dist(mt2, margin = "documents")
     # expect_equal(nrow(tstat), nrow(mt2)^2)
     mat <- as.matrix(tstat)
-    expect_equal(dim(mat), c(quanteda::ndoc(mt2), quanteda::ndoc(mt2)))
+    expect_equal(dim(mat), c(ndoc(mt2), ndoc(mt2)))
     # in matrix, diagonal is 0
-    iden <- rep(0, quanteda::ndoc(mt2)); names(iden) <- quanteda::docnames(mt2)
+    iden <- rep(0, ndoc(mt2)); names(iden) <- docnames(mt2)
     expect_equal(diag(mat), iden)
 
     # upper = TRUE, diag = FALSE
     tstat <- textstat_dist(mt2, margin = "documents")
-    # expect_equal(nrow(tstat), nrow(mt2)^2 - quanteda::ndoc(mt2))
+    # expect_equal(nrow(tstat), nrow(mt2)^2 - ndoc(mt2))
     mat <- as.matrix(tstat)
-    expect_equal(dim(mat), c(quanteda::ndoc(mt2), quanteda::ndoc(mt2)))
-    iden <- rep(0, quanteda::ndoc(mt2))
-    names(iden) <- quanteda::docnames(mt2)
+    expect_equal(dim(mat), c(ndoc(mt2), ndoc(mt2)))
+    iden <- rep(0, ndoc(mt2))
+    names(iden) <- docnames(mt2)
     expect_equal(diag(mat), iden)
 
     # upper = FALSE, diag = TRUE
@@ -164,8 +163,8 @@ test_that("textstat_dist coercion methods work with options", {
     mat <- as.matrix(tstat)
     # expect_true(all(is.na(mat[upper.tri(mat)])))
     # in matrix, diagonal is 0
-    iden <- rep(0, quanteda::ndoc(mt2))
-    names(iden) <- quanteda::docnames(mt2)
+    iden <- rep(0, ndoc(mt2))
+    names(iden) <- docnames(mt2)
     expect_equal(diag(as.matrix(tstat)), iden)
 
     # upper = FALSE, diag = FALSE
@@ -176,6 +175,6 @@ test_that("textstat_dist coercion methods work with options", {
     diag(loweranddiag) <- TRUE
     # expect_true(all(is.na(mat[upper.tri(mat)])))
     # in matrix, diagonal is 0
-    iden <- rep(0, quanteda::ndoc(mt2)); names(iden) <- quanteda::docnames(mt2)
+    iden <- rep(0, ndoc(mt2)); names(iden) <- docnames(mt2)
     expect_equal(diag(mat), iden)
 })

--- a/tests/testthat/test-textstat_proxy.R
+++ b/tests/testthat/test-textstat_proxy.R
@@ -312,14 +312,14 @@ test_that("use_na is working", {
     euc1 <- textstat_proxy(mt, margin = "features", method = "euclidean", use_na = TRUE)
     expect_equal(sum(is.na(cos1)), 5)
     expect_equal(sum(is.na(cor1)), 8)
-    expect_equal(sum(is.na(euc1)), 5)
+    expect_equal(sum(is.na(euc1)), 0)
 
     cos2 <- textstat_proxy(mt, mt[, 3], margin = "features", method = "cosine", use_na = TRUE)
     cor2 <- textstat_proxy(mt, mt[, 3], margin = "features", method = "correlation", use_na = TRUE)
     euc2 <- textstat_proxy(mt, mt[, 3], margin = "features", method = "euclidean", use_na = TRUE)
     expect_equal(sum(is.na(cos2)), 1)
     expect_equal(sum(is.na(cor2)), 2)
-    expect_equal(sum(is.na(euc2)), 1)
+    expect_equal(sum(is.na(euc2)), 0)
 })
 
 test_that("no value is greater than 1.0 (#1543)", {


### PR DESCRIPTION
Use the `use_nan` argument that was added to proxyC recently. It's functions return the NaN for the empty or uniform vectors in the same way as `proxy::simil()` or `stats::dist()`, but it is only when measures are correlation or cosine. 

proxyC returns zero when measures are based on set-theory or vector space model, because common elements of empty sets are zero and distance between origins are zero. Cosine is also a spatial measure but `proxyC::simil()` still returns NaN for empty vectors because its is about angles, not coordinates.