### PR TITLE
Fix Yule's K computation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: quanteda.textstats
-Version: 0.94.1.9000
+Version: 0.94.9000
 Title: Textual Statistics for the Quantitative Analysis of Textual Data
 Description: Textual statistics functions formerly in the 'quanteda' package.
     Textual statistics for characterizing and comparing textual data. Includes 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
-# quanteda.textstats 0.94.2
+# quanteda.textstats 0.95
 
 * Updated `textstat_simil()` for new **proxyC** version v0.2.2, which affects how similarities are returned for `NA` values.  See #45.
+* Fixed a bug in the computation of Yule's K (#46)
 
 # quanteda.textstats 0.94.1
 

--- a/R/textstat_lexdiv.R
+++ b/R/textstat_lexdiv.R
@@ -337,7 +337,7 @@ compute_lexdiv_dfm_stats <- function(x, measure = NULL, log.base = 10) {
     }
 
     if ("K" %in% measure)
-        result[["K"]] <- 10 ^ 4 * vapply(ViN, function(y) sum(y$ViN * (y$i / y$n_tokens) ^ 2), numeric(1))
+        result[["K"]] <- 10 ^ 4 * vapply(ViN, function(y) (-1 / y$n_tokens[1]) + sum(y$ViN * (y$i / y$n_tokens) ^ 2), numeric(1))
     if ("I" %in% measure) {
         M_2 <- vapply(ViN, function(y) sum(y$ViN * y$i^2), numeric(1))
         M_1 <- n_types


### PR DESCRIPTION
The previous formula had omitted a -1/N in the formula. Corrected now with tests to compare results to koRpus and to a published result (although that publication has computation and/or rounding errors).

Closes #46.